### PR TITLE
feature: kutils upgrade, more configuration options

### DIFF
--- a/commands.md
+++ b/commands.md
@@ -11,7 +11,9 @@
 | disable                     | <none>    | Disable the bot                       |
 | enable                      | <none>    | Enable the bot                        |
 | setMode                     | mode      | Set the mode to prefix or suffix      |
-| setNickSymbol               | Text      | Set the token to appear in nicknames. |
+| setNickSymbol               | Symbol    | Set the token to appear in nicknames. |
+| setOwner                    | Member    | Set the owner & admin of the bot.     |
+| setPrefix                   | Prefix    | Set the bot's invocation prefix       |
 | toggleFunctionality, toggle | <none>    | Toggles the bot functionality         |
 
 ## Utility

--- a/commands.md
+++ b/commands.md
@@ -6,15 +6,16 @@
 | (Argument) | This argument is optional. |
 
 ## Admin
-| Commands                    | Arguments | Description                           |
-| --------------------------- | --------- | ------------------------------------- |
-| disable                     | <none>    | Disable the bot                       |
-| enable                      | <none>    | Enable the bot                        |
-| setMode                     | mode      | Set the mode to prefix or suffix      |
-| setNickSymbol               | Symbol    | Set the token to appear in nicknames. |
-| setOwner                    | Member    | Set the owner & admin of the bot.     |
-| setPrefix                   | Prefix    | Set the bot's invocation prefix       |
-| toggleFunctionality, toggle | <none>    | Toggles the bot functionality         |
+| Commands                    | Arguments | Description                                   |
+| --------------------------- | --------- | --------------------------------------------- |
+| disable                     | <none>    | Disable the bot                               |
+| enable                      | <none>    | Enable the bot                                |
+| setMode                     | mode      | Set the mode to prefix or suffix              |
+| setNickSymbol               | Symbol    | Set the token to appear in nicknames.         |
+| setOwner                    | Member    | Set the owner & admin of the bot.             |
+| setPrefix                   | Prefix    | Set the bot's invocation prefix               |
+| setRole                     | Role      | Set the role that will have symbols enforced. |
+| toggleFunctionality, toggle | <none>    | Toggles the bot functionality                 |
 
 ## Utility
 | Commands | Arguments | Description          |

--- a/commands.md
+++ b/commands.md
@@ -6,13 +6,13 @@
 | (Argument) | This argument is optional. |
 
 ## Admin
-| Commands                    | Arguments | Description                      |
-| --------------------------- | --------- | -------------------------------- |
-| disable                     | <none>    | Disable the bot                  |
-| enable                      | <none>    | Enable the bot                   |
-| setMode                     | mode      | Set the mode to prefix or suffix |
-| setPrefix                   | Text      | Set the mode to prefix or suffix |
-| toggleFunctionality, toggle | <none>    | Toggles the bot functionality    |
+| Commands                    | Arguments | Description                           |
+| --------------------------- | --------- | ------------------------------------- |
+| disable                     | <none>    | Disable the bot                       |
+| enable                      | <none>    | Enable the bot                        |
+| setMode                     | mode      | Set the mode to prefix or suffix      |
+| setNickSymbol               | Text      | Set the token to appear in nicknames. |
+| toggleFunctionality, toggle | <none>    | Toggles the bot functionality         |
 
 ## Utility
 | Commands | Arguments | Description          |

--- a/commands.md
+++ b/commands.md
@@ -6,11 +6,13 @@
 | (Argument) | This argument is optional. |
 
 ## Admin
-| Commands                    | Arguments | Description                   |
-| --------------------------- | --------- | ----------------------------- |
-| disable                     | <none>    | Disable the bot               |
-| enable                      | <none>    | Enable the bot                |
-| toggleFunctionality, toggle | <none>    | Toggles the bot functionality |
+| Commands                    | Arguments | Description                      |
+| --------------------------- | --------- | -------------------------------- |
+| disable                     | <none>    | Disable the bot                  |
+| enable                      | <none>    | Enable the bot                   |
+| setMode                     | mode      | Set the mode to prefix or suffix |
+| setPrefix                   | Text      | Set the mode to prefix or suffix |
+| toggleFunctionality, toggle | <none>    | Toggles the bot functionality    |
 
 ## Utility
 | Commands | Arguments | Description          |

--- a/pom.xml
+++ b/pom.xml
@@ -6,11 +6,12 @@
 
     <groupId>org.example</groupId>
     <artifactId>Hawk</artifactId>
-    <version>1.1.0</version>
+    <version>1.2.0</version>
 
     <properties>
-        <kotlin.version>1.3.61</kotlin.version>
-        <kutils.version>0.13.1</kutils.version>
+        <kotlin.version>1.3.71</kotlin.version>
+        <kutils.version>0.15.1</kutils.version>
+        <project.repository>https://github.com/the-programmers-hangout/Hawk</project.repository>
     </properties>
 
     <dependencies>
@@ -35,6 +36,15 @@
     <build>
         <sourceDirectory>src/main/kotlin</sourceDirectory>
         <testSourceDirectory>src/test/kotlin</testSourceDirectory>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <includes>
+                    <include>**/*.json</include>
+                </includes>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
         <plugins>
             <plugin>
                 <groupId>org.jetbrains.kotlin</groupId>

--- a/src/main/kotlin/me/aberrantfox/hawk/Main.kt
+++ b/src/main/kotlin/me/aberrantfox/hawk/Main.kt
@@ -39,7 +39,6 @@ fun main(args: Array<String>) {
                 with(project) {
                     val self = it.guild.jda.selfUser
                     val kotlinVersion = KotlinVersion.CURRENT
-                    val requiredRole = configuration.staffRole ?: "<Not Configured>"
                     val milliseconds = Date().time - startTime.time
                     val seconds = (milliseconds / 1000) % 60
                     val minutes = (milliseconds / (1000 * 60)) % 60
@@ -51,16 +50,24 @@ fun main(args: Array<String>) {
                     addField(self.fullName(), "A bot to add and maintain a symbol as a prefix or suffix in staff names.")
                     addInlineField("Prefix", configuration.botPrefix)
                     addInlineField("Ping", "${discord.jda.gatewayPing}ms")
-                    addField("Uptime", "$days day(s), " +
-                            "$hours hour(s), " +
-                            "$minutes minute(s) " +
-                            "and $seconds second(s)")
+
+                    addField("Config Info", "```" +
+                            "Mode: ${configuration.mode}\n" +
+                            "Role: ${configuration.staffRole}\n" +
+                            "Symbol: ${configuration.nickSymbol}\n" +
+                            "Enabled: ${configuration.enabled}" +
+                            "```")
 
                     addField("Build Info", "```" +
                             "Version: $version\n" +
                             "KUtils: $kutils\n" +
                             "Kotlin: $kotlinVersion" +
                             "```")
+
+                    addField("Uptime", "$days day(s), " +
+                            "$hours hour(s), " +
+                            "$minutes minute(s) " +
+                            "and $seconds second(s)")
 
                     addInlineField("Source", repository)
                 }

--- a/src/main/kotlin/me/aberrantfox/hawk/Main.kt
+++ b/src/main/kotlin/me/aberrantfox/hawk/Main.kt
@@ -12,6 +12,7 @@ import kotlin.system.exitProcess
 data class Properties(val author: String, val version: String, val kutils: String, val repository: String)
 private val propFile = Properties::class.java.getResource("/properties.json").readText()
 val project: Properties = Gson().fromJson(propFile, Properties::class.java)
+val startTime = Date()
 
 fun main(args: Array<String>) {
     val token = args.firstOrNull()
@@ -39,7 +40,6 @@ fun main(args: Array<String>) {
                     val self = it.guild.jda.selfUser
                     val kotlinVersion = KotlinVersion.CURRENT
                     val requiredRole = configuration.staffRole ?: "<Not Configured>"
-                    val startTime = Date()
                     val milliseconds = Date().time - startTime.time
                     val seconds = (milliseconds / 1000) % 60
                     val minutes = (milliseconds / (1000 * 60)) % 60
@@ -56,7 +56,7 @@ fun main(args: Array<String>) {
                             "$minutes minute(s) " +
                             "and $seconds second(s)")
 
-                    addField("Build Info", "``" +
+                    addField("Build Info", "```" +
                             "Version: $version\n" +
                             "KUtils: $kutils\n" +
                             "Kotlin: $kotlinVersion" +

--- a/src/main/kotlin/me/aberrantfox/hawk/Main.kt
+++ b/src/main/kotlin/me/aberrantfox/hawk/Main.kt
@@ -1,8 +1,17 @@
 package me.aberrantfox.hawk
 
+import com.google.gson.Gson
+import me.aberrantfox.hawk.configuration.BotConfiguration
+import me.aberrantfox.kjdautils.api.getInjectionObject
 import me.aberrantfox.kjdautils.api.startBot
+import me.aberrantfox.kjdautils.extensions.jda.fullName
+import java.awt.Color
+import java.util.*
 import kotlin.system.exitProcess
 
+data class Properties(val author: String, val version: String, val kutils: String, val repository: String)
+private val propFile = Properties::class.java.getResource("/properties.json").readText()
+val project: Properties = Gson().fromJson(propFile, Properties::class.java)
 
 fun main(args: Array<String>) {
     val token = args.firstOrNull()
@@ -12,9 +21,51 @@ fun main(args: Array<String>) {
         exitProcess(-1)
     }
 
-    startBot(token) {
+    startBot(token, "me.aberrantfox.hawk.") {
         configure {
-            globalPath = "me.aberrantfox.hawk."
+            val configuration: BotConfiguration = discord.getInjectionObject<BotConfiguration>()!!
+            prefix = configuration.botPrefix
+            allowMentionPrefix = true
+
+            colors {
+                infoColor = Color.CYAN
+                failureColor = Color.RED
+                successColor = Color.GREEN
+            }
+
+
+            mentionEmbed {
+                with(project) {
+                    val self = it.guild.jda.selfUser
+                    val kotlinVersion = KotlinVersion.CURRENT
+                    val requiredRole = configuration.staffRole ?: "<Not Configured>"
+                    val startTime = Date()
+                    val milliseconds = Date().time - startTime.time
+                    val seconds = (milliseconds / 1000) % 60
+                    val minutes = (milliseconds / (1000 * 60)) % 60
+                    val hours = (milliseconds / (1000 * 60 * 60)) % 24
+                    val days = (milliseconds / (1000 * 60 * 60 * 24))
+
+                    color = infoColor
+                    thumbnail = self.effectiveAvatarUrl
+                    addField(self.fullName(), "A bot to add and maintain a symbol as a prefix or suffix in staff names.")
+                    addInlineField("Prefix", configuration.botPrefix)
+                    addInlineField("Ping", "${discord.jda.gatewayPing}ms")
+                    addField("Uptime", "$days day(s), " +
+                            "$hours hour(s), " +
+                            "$minutes minute(s) " +
+                            "and $seconds second(s)")
+
+                    addField("Build Info", "``" +
+                            "Version: $version\n" +
+                            "KUtils: $kutils\n" +
+                            "Kotlin: $kotlinVersion" +
+                            "```")
+
+                    addInlineField("Source", repository)
+                }
+            }
+
         }
     }
 }

--- a/src/main/kotlin/me/aberrantfox/hawk/commands/AdministrationCommands.kt
+++ b/src/main/kotlin/me/aberrantfox/hawk/commands/AdministrationCommands.kt
@@ -4,7 +4,8 @@ import me.aberrantfox.hawk.configuration.BotConfiguration
 import me.aberrantfox.kjdautils.api.annotation.CommandSet
 import me.aberrantfox.kjdautils.api.dsl.command.commands
 import me.aberrantfox.kjdautils.internal.arguments.ChoiceArg
-import me.aberrantfox.kjdautils.internal.arguments.SentenceArg
+import me.aberrantfox.kjdautils.internal.arguments.MemberArg
+import me.aberrantfox.kjdautils.internal.arguments.WordArg
 import me.aberrantfox.kjdautils.internal.services.PersistenceService
 
 @CommandSet("Admin")
@@ -47,12 +48,30 @@ fun createAdministrationCommands(botConfiguration: BotConfiguration, persistence
 
     command("setNickSymbol") {
         description = "Set the token to appear in nicknames."
-        execute(SentenceArg) {
+        execute(WordArg("Symbol")) {
             val symbol = it.args.first
             botConfiguration.nickSymbol = "$symbol "
             botConfiguration.stripString = symbol
             persistenceService.save(botConfiguration)
             it.respond("Set the bots symbol to **${it.args.first}**")
+        }
+    }
+
+    command("setOwner") {
+        description = "Set the owner & admin of the bot."
+        execute(MemberArg) {
+            botConfiguration.owner = it.args.first.id
+            persistenceService.save(botConfiguration)
+            it.respond("Set the bots owner to **${it.args.first.user.asTag}**")
+        }
+    }
+
+    command("setPrefix") {
+        description = "Set the bot's invocation prefix"
+        execute(WordArg("Prefix")) {
+            botConfiguration.botPrefix = it.args.first
+            persistenceService.save(botConfiguration)
+            it.respond("Set the bots owner prefix to **${it.args.first}**")
         }
     }
 }

--- a/src/main/kotlin/me/aberrantfox/hawk/commands/AdministrationCommands.kt
+++ b/src/main/kotlin/me/aberrantfox/hawk/commands/AdministrationCommands.kt
@@ -1,16 +1,20 @@
 package me.aberrantfox.hawk.commands
 
 import me.aberrantfox.hawk.configuration.BotConfiguration
-import me.aberrantfox.kjdautils.api.dsl.command.CommandSet
+import me.aberrantfox.kjdautils.api.annotation.CommandSet
 import me.aberrantfox.kjdautils.api.dsl.command.commands
+import me.aberrantfox.kjdautils.internal.arguments.ChoiceArg
+import me.aberrantfox.kjdautils.internal.arguments.SentenceArg
+import me.aberrantfox.kjdautils.internal.services.PersistenceService
 
 @CommandSet("Admin")
-fun createAdministrationCommands(botConfiguration: BotConfiguration) = commands {
+fun createAdministrationCommands(botConfiguration: BotConfiguration, persistenceService: PersistenceService) = commands {
     command("toggleFunctionality", "toggle") {
         description = "Toggles the bot functionality"
         execute {
             botConfiguration.enabled = !botConfiguration.enabled
-            it.respond("Toggled Bot Status: ${botConfiguration.enabled}")
+            persistenceService.save(botConfiguration)
+            it.respond("Bot has been turned **${if(botConfiguration.enabled) "On" else "Off"}**")
         }
     }
 
@@ -18,6 +22,7 @@ fun createAdministrationCommands(botConfiguration: BotConfiguration) = commands 
         description = "Enable the bot"
         execute {
             botConfiguration.enabled = true
+            persistenceService.save(botConfiguration)
             it.respond("Enabled the bot. Listening.")
         }
     }
@@ -26,7 +31,28 @@ fun createAdministrationCommands(botConfiguration: BotConfiguration) = commands 
         description = "Disable the bot"
         execute {
             botConfiguration.enabled = false
+            persistenceService.save(botConfiguration)
             it.respond("Disabled the bot. Events will be ignored as well as commands other than toggle/enable/disable.")
+        }
+    }
+
+    command("setMode") {
+        description = "Set the mode to prefix or suffix"
+        execute(ChoiceArg("mode", "prefix", "suffix")) {
+            botConfiguration.mode = it.args.first
+            persistenceService.save(botConfiguration)
+            it.respond("Set the bots nickname mode to **${it.args.first}**.")
+        }
+    }
+
+    command("setPrefix") {
+        description = "Set the token to appear in nicknames."
+        execute(SentenceArg) {
+            val symbol = it.args.first
+            botConfiguration.nickSymbol = "$symbol "
+            botConfiguration.stripString = symbol
+            persistenceService.save(botConfiguration)
+            it.respond("Set the bots prefix to **${it.args.first}**.")
         }
     }
 }

--- a/src/main/kotlin/me/aberrantfox/hawk/commands/AdministrationCommands.kt
+++ b/src/main/kotlin/me/aberrantfox/hawk/commands/AdministrationCommands.kt
@@ -5,6 +5,7 @@ import me.aberrantfox.kjdautils.api.annotation.CommandSet
 import me.aberrantfox.kjdautils.api.dsl.command.commands
 import me.aberrantfox.kjdautils.internal.arguments.ChoiceArg
 import me.aberrantfox.kjdautils.internal.arguments.MemberArg
+import me.aberrantfox.kjdautils.internal.arguments.RoleArg
 import me.aberrantfox.kjdautils.internal.arguments.WordArg
 import me.aberrantfox.kjdautils.internal.services.PersistenceService
 
@@ -54,6 +55,15 @@ fun createAdministrationCommands(botConfiguration: BotConfiguration, persistence
             botConfiguration.stripString = symbol
             persistenceService.save(botConfiguration)
             it.respond("Set the bots symbol to **${it.args.first}**")
+        }
+    }
+
+    command("setRole") {
+        description = "Set the role that will have symbols enforced."
+        execute(RoleArg) {
+            botConfiguration.staffRole = it.args.first.name
+            persistenceService.save(botConfiguration)
+            it.respond("Set the bots role to **${it.args.first.name}**")
         }
     }
 

--- a/src/main/kotlin/me/aberrantfox/hawk/commands/AdministrationCommands.kt
+++ b/src/main/kotlin/me/aberrantfox/hawk/commands/AdministrationCommands.kt
@@ -45,14 +45,14 @@ fun createAdministrationCommands(botConfiguration: BotConfiguration, persistence
         }
     }
 
-    command("setPrefix") {
+    command("setNickSymbol") {
         description = "Set the token to appear in nicknames."
         execute(SentenceArg) {
             val symbol = it.args.first
             botConfiguration.nickSymbol = "$symbol "
             botConfiguration.stripString = symbol
             persistenceService.save(botConfiguration)
-            it.respond("Set the bots prefix to **${it.args.first}**.")
+            it.respond("Set the bots symbol to **${it.args.first}**")
         }
     }
 }

--- a/src/main/kotlin/me/aberrantfox/hawk/configuration/BotConfiguration.kt
+++ b/src/main/kotlin/me/aberrantfox/hawk/configuration/BotConfiguration.kt
@@ -5,8 +5,8 @@ import me.aberrantfox.kjdautils.api.annotation.Data
 @Data("data/configuration.json")
 data class BotConfiguration(
         val guild: String = "<insert-guild>",
-        val owner: String = "<insert-id>",
-        val botPrefix: String = "hawk!",
+        var owner: String = "<insert-id>",
+        var botPrefix: String = "hawk!",
         var nickSymbol: String = "\uD83D\uDD28 ",
         var enabled: Boolean = true,
         var staffRole: String = "Staff",

--- a/src/main/kotlin/me/aberrantfox/hawk/configuration/BotConfiguration.kt
+++ b/src/main/kotlin/me/aberrantfox/hawk/configuration/BotConfiguration.kt
@@ -4,10 +4,12 @@ import me.aberrantfox.kjdautils.api.annotation.Data
 
 @Data("data/configuration.json")
 data class BotConfiguration(
-        val guild: String = "244230771232079873",
-        val owner: String = "222164217707364362",
-        val nickPrefix: String = "\uD83D\uDD28 ",
+        val guild: String = "<insert-guild>",
+        val owner: String = "<insert-id>",
+        val botPrefix: String = "hawk!",
+        var nickSymbol: String = "\uD83D\uDD28 ",
         var enabled: Boolean = true,
         var staffRole: String = "Staff",
-        var stripString: String = "\uD83D\uDD28"
+        var stripString: String = "\uD83D\uDD28",
+        var mode: String = "suffix"
 )

--- a/src/main/kotlin/me/aberrantfox/hawk/preconditions/IsOwnerPrecondition.kt
+++ b/src/main/kotlin/me/aberrantfox/hawk/preconditions/IsOwnerPrecondition.kt
@@ -8,5 +8,5 @@ import me.aberrantfox.kjdautils.internal.command.precondition
 
 @Precondition
 fun isOwner(configuration: BotConfiguration) = precondition { event ->
-    if(event.author.id != configuration.owner) Fail("") else Pass
+    if(event.author.id != configuration.owner) Fail("Commands can only be used by the bot owner.") else Pass
 }

--- a/src/main/kotlin/me/aberrantfox/hawk/preconditions/IsOwnerPrecondition.kt
+++ b/src/main/kotlin/me/aberrantfox/hawk/preconditions/IsOwnerPrecondition.kt
@@ -1,10 +1,10 @@
 package me.aberrantfox.hawk.preconditions
 
 import me.aberrantfox.hawk.configuration.BotConfiguration
-import me.aberrantfox.kjdautils.api.dsl.Precondition
-import me.aberrantfox.kjdautils.api.dsl.precondition
+import me.aberrantfox.kjdautils.api.annotation.Precondition
 import me.aberrantfox.kjdautils.internal.command.Fail
 import me.aberrantfox.kjdautils.internal.command.Pass
+import me.aberrantfox.kjdautils.internal.command.precondition
 
 @Precondition
 fun isOwner(configuration: BotConfiguration) = precondition { event ->

--- a/src/main/resources/properties.json
+++ b/src/main/resources/properties.json
@@ -1,0 +1,6 @@
+{
+  "author": "${project.author}",
+  "version": "${version}",
+  "kutils": "${kutils.version}",
+  "repository": "${project.repository}"
+}


### PR DESCRIPTION
## feature: kutils upgrade, more configuration options
Add more configuration options to the bot (mode, symbol) and update KUtils version.

Added:
- Added new `suffix` mode for the bot to add symbol as a suffix in nicknames.
- Added a botprefix.
- Added commands to set the mode and change the nickname symbol.
- Updated to KUtils 0.15.1
  - Added mention embed.
  - Enabled mention prefix.
  - Set colours.
  - Added resources file for mention embed information.
   - Updated Kotlin version.