### PR TITLE
feat: add party mode

### DIFF
--- a/commands.md
+++ b/commands.md
@@ -6,16 +6,19 @@
 | (Argument) | This argument is optional. |
 
 ## Admin
-| Commands  | Arguments | Description                                   |
-| --------- | --------- | --------------------------------------------- |
-| disable   | <none>    | Disable the bot                               |
-| enable    | <none>    | Enable the bot                                |
-| setMode   | mode      | Set the mode to prefix or suffix              |
-| setOwner  | Member    | Set the owner & admin of the bot.             |
-| setPrefix | Prefix    | Set the bot's invocation prefix               |
-| setRole   | Role      | Set the role that will have symbols enforced. |
-| setSymbol | Symbol    | Set the token to appear in nicknames.         |
-| toggle    | <none>    | Toggles the bot functionality                 |
+| Commands       | Arguments | Description                                   |
+| -------------- | --------- | --------------------------------------------- |
+| disable        | <none>    | Disable the bot                               |
+| enable         | <none>    | Enable the bot                                |
+| getPartySuffix | <none>    | Display current party mode suffix             |
+| setMode        | mode      | Set the mode to prefix or suffix              |
+| setOwner       | Member    | Set the owner & admin of the bot.             |
+| setPartySuffix | Suffix    | Set new party mode suffix                     |
+| setPrefix      | Prefix    | Set the bot's invocation prefix               |
+| setRole        | Role      | Set the role that will have symbols enforced. |
+| setSymbol      | Symbol    | Set the token to appear in nicknames.         |
+| toggle         | <none>    | Toggles the bot functionality                 |
+| toggleParty    | <none>    | Toggles party mode                            |
 
 ## Utility
 | Commands | Arguments | Description          |

--- a/src/main/kotlin/me/aberrantfox/hawk/commands/AdministrationCommands.kt
+++ b/src/main/kotlin/me/aberrantfox/hawk/commands/AdministrationCommands.kt
@@ -7,6 +7,7 @@ import me.aberrantfox.kjdautils.internal.arguments.ChoiceArg
 import me.aberrantfox.kjdautils.internal.arguments.MemberArg
 import me.aberrantfox.kjdautils.internal.arguments.RoleArg
 import me.aberrantfox.kjdautils.internal.arguments.AnyArg
+import me.aberrantfox.kjdautils.internal.arguments.EveryArg
 import me.aberrantfox.kjdautils.internal.services.PersistenceService
 
 @CommandSet("Admin")
@@ -82,6 +83,33 @@ fun createAdministrationCommands(botConfiguration: BotConfiguration, persistence
             botConfiguration.botPrefix = it.args.first
             persistenceService.save(botConfiguration)
             it.respond("Set the bots owner prefix to **${it.args.first}**")
+        }
+    }
+    
+    command("toggleParty") {
+        description = "Toggles party mode"
+        execute {
+            botConfiguration.partyMode = !botConfiguration.partyMode
+            persistenceService.save(botConfiguration)
+            it.respond("${if(botConfiguration.partyMode) "Let's get this party started!" else "We're done. That's all folks!"}")
+        }
+    }
+    
+    command("getPartySuffix") {
+        description = "Display current party mode suffix"
+        execute {
+            it.respond("Suffix: ${botConfiguration.partySuffix}")
+        }
+    }
+    
+    command("setPartySuffix") {
+        description = "Set new party mode suffix"
+        execute (EveryArg("Suffix")){
+            val symbol = it.args.first.replace("\uD83D\uDD28", "")
+            botConfiguration.partySuffix = "$symbol "
+            botConfiguration.partyStrip = symbol
+            persistenceService.save(botConfiguration)
+            it.respond("Set the party suffix to **${symbol}**")
         }
     }
 }

--- a/src/main/kotlin/me/aberrantfox/hawk/configuration/BotConfiguration.kt
+++ b/src/main/kotlin/me/aberrantfox/hawk/configuration/BotConfiguration.kt
@@ -11,5 +11,8 @@ data class BotConfiguration(
         var enabled: Boolean = true,
         var staffRole: String = "Staff",
         var stripString: String = "\uD83D\uDD28",
-        var mode: String = "suffix"
+        var mode: String = "suffix",
+        var partyMode: Boolean = false,
+        var partySuffix: String = "\ud83e\udd73 ",
+        var partyStrip: String = "\ud83e\udd73"
 )

--- a/src/main/kotlin/me/aberrantfox/hawk/extensions/jda/GuildMemberExtensions.kt
+++ b/src/main/kotlin/me/aberrantfox/hawk/extensions/jda/GuildMemberExtensions.kt
@@ -79,6 +79,21 @@ fun Member.ensureCorrectEffectiveName(guild: Guild, configuration: BotConfigurat
     } else {
         this.ensureNoHammer(configuration, guild.selfMember, action)
     }
+    this.setPartySuffix(configuration)
+}
+
+fun Member.setPartySuffix(configuration: BotConfiguration) {
+    if (configuration.partyMode) {
+        val nick = applyNickPrefix(effectiveName, configuration.partySuffix, configuration.partyStrip, "suffix")
+        modifyNickname(nick).queue {
+            println("Added party suffix for ${this.fullName()}")
+        }
+    } else if (effectiveName.endsWith(configuration.partySuffix) || effectiveName.endsWith(configuration.partyStrip)){
+        val nick = removeNickPrefix(effectiveName, configuration.partyStrip)
+        modifyNickname(nick).queue {
+            println("Removed party suffix for ${this.fullName()}")
+        }
+    }
 }
 
 fun Member.determineNewNickName(configuration: BotConfiguration) =


### PR DESCRIPTION
Adds party mode to HawkBot
`hawk!toggleParty` enables or disables the party.
When party mode is enabled, any user sending a message will have their nicknames altered with the party suffix.
When party mode is disabled, users will have the party suffix removed.

`hawk!getPartySuffix` allows the user to view the current suffix.
`hawk!setPartySuffix` allows the user to set the suffix.