### PR TITLE
Add length check to party mode suffix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.example</groupId>
     <artifactId>Hawk</artifactId>
-    <version>1.3.1</version>
+    <version>1.3.2</version>
 
     <properties>
         <kotlin.version>1.3.71</kotlin.version>

--- a/src/main/kotlin/me/aberrantfox/hawk/commands/AdministrationCommands.kt
+++ b/src/main/kotlin/me/aberrantfox/hawk/commands/AdministrationCommands.kt
@@ -106,10 +106,14 @@ fun createAdministrationCommands(botConfiguration: BotConfiguration, persistence
         description = "Set new party mode suffix"
         execute (EveryArg("Suffix")){
             val symbol = it.args.first.replace("\uD83D\uDD28", "")
-            botConfiguration.partySuffix = "$symbol "
-            botConfiguration.partyStrip = symbol
-            persistenceService.save(botConfiguration)
-            it.respond("Set the party suffix to **${symbol}**")
+            if (symbol.length > 11 || symbol.isEmpty()) {
+                it.respond("Suffix is must be shorter than 11 characters and not empty!")
+            } else {
+                botConfiguration.partySuffix = "$symbol "
+                botConfiguration.partyStrip = symbol
+                persistenceService.save(botConfiguration)
+                it.respond("Set the party suffix to **${symbol}**")
+            }
         }
     }
 }


### PR DESCRIPTION
Requires the suffix to be non-empty and less than or equal to 11 characters in length. Gives enough room for 4 emojis with spaces between them.