### PR TITLE
feat: change to discordkt, split commands

### DIFF
--- a/commands.md
+++ b/commands.md
@@ -1,24 +1,32 @@
 # Commands
 
-## Key
-| Symbol     | Meaning                    |
-| ---------- | -------------------------- |
-| (Argument) | This argument is optional. |
+## Key 
+| Symbol      | Meaning                        |
+| ----------- | ------------------------------ |
+| (Argument)  | Argument is not required.      |
 
 ## Admin
-| Commands       | Arguments | Description                                   |
-| -------------- | --------- | --------------------------------------------- |
-| disable        | <none>    | Disable the bot                               |
-| enable         | <none>    | Enable the bot                                |
-| getPartySuffix | <none>    | Display current party mode suffix             |
-| setMode        | mode      | Set the mode to prefix or suffix              |
-| setOwner       | Member    | Set the owner & admin of the bot.             |
-| setPartySuffix | Suffix    | Set new party mode suffix                     |
-| setPrefix      | Prefix    | Set the bot's invocation prefix               |
-| setRole        | Role      | Set the role that will have symbols enforced. |
-| setSymbol      | Symbol    | Set the token to appear in nicknames.         |
-| toggle         | <none>    | Toggles the bot functionality                 |
-| toggleParty    | <none>    | Toggles party mode                            |
+| Commands | Arguments | Description                   |
+| -------- | --------- | ----------------------------- |
+| disable  |           | Disable the bot               |
+| enable   |           | Enable the bot                |
+| toggle   |           | Toggles the bot functionality |
+
+## Config
+| Commands  | Arguments | Description                                   |
+| --------- | --------- | --------------------------------------------- |
+| setMode   | mode      | Set the mode to prefix or suffix              |
+| setOwner  | Member    | Set the owner & admin of the bot.             |
+| setPrefix | Prefix    | Set the bot's invocation prefix               |
+| setRole   | Role      | Set the role that will have symbols enforced. |
+| setSymbol | Symbol    | Set the token to appear in nicknames.         |
+
+## Party
+| Commands       | Arguments | Description                       |
+| -------------- | --------- | --------------------------------- |
+| getPartySuffix |           | Display current party mode suffix |
+| setPartySuffix | Suffix    | Set new party mode suffix         |
+| toggleParty    |           | Toggles party mode                |
 
 ## Utility
 | Commands | Arguments | Description          |

--- a/pom.xml
+++ b/pom.xml
@@ -6,11 +6,11 @@
 
     <groupId>org.example</groupId>
     <artifactId>Hawk</artifactId>
-    <version>1.3.2</version>
+    <version>1.3.3</version>
 
     <properties>
         <kotlin.version>1.3.71</kotlin.version>
-        <kutils.version>0.16.0</kutils.version>
+        <discordKt.version>0.19.1</discordKt.version>
         <project.repository>https://github.com/the-programmers-hangout/Hawk</project.repository>
     </properties>
 
@@ -27,9 +27,9 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.gitlab.aberrantfox</groupId>
-            <artifactId>KUtils</artifactId>
-            <version>${kutils.version}</version>
+            <groupId>me.jakejmattson</groupId>
+            <artifactId>DiscordKt</artifactId>
+            <version>${discordKt.version}</version>
         </dependency>
     </dependencies>
 

--- a/src/main/kotlin/me/aberrantfox/hawk/Main.kt
+++ b/src/main/kotlin/me/aberrantfox/hawk/Main.kt
@@ -2,14 +2,13 @@ package me.aberrantfox.hawk
 
 import com.google.gson.Gson
 import me.aberrantfox.hawk.configuration.BotConfiguration
-import me.aberrantfox.kjdautils.api.getInjectionObject
-import me.aberrantfox.kjdautils.api.startBot
-import me.aberrantfox.kjdautils.extensions.jda.fullName
+import me.jakejmattson.discordkt.api.dsl.bot
+import me.jakejmattson.discordkt.api.extensions.jda.fullName
 import java.awt.Color
 import java.util.*
 import kotlin.system.exitProcess
 
-data class Properties(val author: String, val version: String, val kutils: String, val repository: String)
+data class Properties(val author: String, val version: String, val discordKt: String, val repository: String)
 private val propFile = Properties::class.java.getResource("/properties.json").readText()
 val project: Properties = Gson().fromJson(propFile, Properties::class.java)
 val startTime = Date()
@@ -22,9 +21,9 @@ fun main(args: Array<String>) {
         exitProcess(-1)
     }
 
-    startBot(token, globalPath = "me.aberrantfox.hawk.") {
+    bot(token) {
         configure {
-            val configuration: BotConfiguration = discord.getInjectionObject<BotConfiguration>()!!
+            val configuration = it.getInjectionObjects(BotConfiguration::class)
             prefix { configuration.botPrefix }
             allowMentionPrefix = true
 
@@ -49,18 +48,18 @@ fun main(args: Array<String>) {
                     thumbnail = self.effectiveAvatarUrl
                     addField(self.fullName(), "A bot to add and maintain a symbol as a prefix or suffix in staff names.")
                     addInlineField("Prefix", configuration.botPrefix)
-                    addInlineField("Ping", "${discord.jda.gatewayPing}ms")
 
                     addField("Config Info", "```" +
+                            "Enabled: ${configuration.enabled}\n" +
                             "Mode: ${configuration.mode}\n" +
                             "Role: ${configuration.staffRole}\n" +
                             "Symbol: ${configuration.nickSymbol}\n" +
-                            "Enabled: ${configuration.enabled}" +
+                            "PartySuffix: ${configuration.partySuffix}" +
                             "```")
 
                     addField("Build Info", "```" +
                             "Version: $version\n" +
-                            "KUtils: $kutils\n" +
+                            "DiscordKt: $discordKt\n" +
                             "Kotlin: $kotlinVersion" +
                             "```")
 

--- a/src/main/kotlin/me/aberrantfox/hawk/botdata/Messages.kt
+++ b/src/main/kotlin/me/aberrantfox/hawk/botdata/Messages.kt
@@ -1,9 +1,8 @@
 package me.aberrantfox.hawk.botdata
 
-import me.aberrantfox.kjdautils.api.annotation.Data
+import me.jakejmattson.discordkt.api.dsl.data.Data
 
-@Data("data/messages.json")
 data class Messages(
     val USER_NICK_RESET: String = "Your nickname made it seem like you were a staff member. This has been automatically logged.",
     val STAFF_NICK_PROMPT: String = "You have updated your nickname and it does not contain the prefix. Here it is with the prefix: %1%"
-)
+): Data("data/messages.json")

--- a/src/main/kotlin/me/aberrantfox/hawk/commands/AdministrationCommands.kt
+++ b/src/main/kotlin/me/aberrantfox/hawk/commands/AdministrationCommands.kt
@@ -1,22 +1,16 @@
 package me.aberrantfox.hawk.commands
 
 import me.aberrantfox.hawk.configuration.BotConfiguration
-import me.aberrantfox.kjdautils.api.annotation.CommandSet
-import me.aberrantfox.kjdautils.api.dsl.command.commands
-import me.aberrantfox.kjdautils.internal.arguments.ChoiceArg
-import me.aberrantfox.kjdautils.internal.arguments.MemberArg
-import me.aberrantfox.kjdautils.internal.arguments.RoleArg
-import me.aberrantfox.kjdautils.internal.arguments.AnyArg
-import me.aberrantfox.kjdautils.internal.arguments.EveryArg
-import me.aberrantfox.kjdautils.internal.services.PersistenceService
+import me.jakejmattson.discordkt.api.annotations.CommandSet
+import me.jakejmattson.discordkt.api.dsl.command.commands
 
 @CommandSet("Admin")
-fun createAdministrationCommands(botConfiguration: BotConfiguration, persistenceService: PersistenceService) = commands {
+fun createAdministrationCommands(botConfiguration: BotConfiguration) = commands {
     command("toggle") {
         description = "Toggles the bot functionality"
         execute {
             botConfiguration.enabled = !botConfiguration.enabled
-            persistenceService.save(botConfiguration)
+            botConfiguration.save()
             it.respond("Bot has been turned **${if(botConfiguration.enabled) "On" else "Off"}**")
         }
     }
@@ -25,7 +19,7 @@ fun createAdministrationCommands(botConfiguration: BotConfiguration, persistence
         description = "Enable the bot"
         execute {
             botConfiguration.enabled = true
-            persistenceService.save(botConfiguration)
+            botConfiguration.save()
             it.respond("Enabled the bot. Listening.")
         }
     }
@@ -34,86 +28,10 @@ fun createAdministrationCommands(botConfiguration: BotConfiguration, persistence
         description = "Disable the bot"
         execute {
             botConfiguration.enabled = false
-            persistenceService.save(botConfiguration)
+            botConfiguration.save()
             it.respond("Disabled the bot. Events will be ignored as well as commands other than toggle/enable/disable.")
         }
     }
 
-    command("setMode") {
-        description = "Set the mode to prefix or suffix"
-        execute(ChoiceArg("mode", "prefix", "suffix")) {
-            botConfiguration.mode = it.args.first
-            persistenceService.save(botConfiguration)
-            it.respond("Set the bots nickname mode to **${it.args.first}**.")
-        }
-    }
 
-    command("setSymbol") {
-        description = "Set the token to appear in nicknames."
-        execute(AnyArg("Symbol")) {
-            val symbol = it.args.first
-            botConfiguration.nickSymbol = "$symbol "
-            botConfiguration.stripString = symbol
-            persistenceService.save(botConfiguration)
-            it.respond("Set the bots symbol to **${it.args.first}**")
-        }
-    }
-
-    command("setRole") {
-        description = "Set the role that will have symbols enforced."
-        execute(RoleArg) {
-            botConfiguration.staffRole = it.args.first.name
-            persistenceService.save(botConfiguration)
-            it.respond("Set the bots role to **${it.args.first.name}**")
-        }
-    }
-
-    command("setOwner") {
-        description = "Set the owner & admin of the bot."
-        execute(MemberArg) {
-            botConfiguration.owner = it.args.first.id
-            persistenceService.save(botConfiguration)
-            it.respond("Set the bots owner to **${it.args.first.user.asTag}**")
-        }
-    }
-
-    command("setPrefix") {
-        description = "Set the bot's invocation prefix"
-        execute(AnyArg("Prefix")) {
-            botConfiguration.botPrefix = it.args.first
-            persistenceService.save(botConfiguration)
-            it.respond("Set the bots owner prefix to **${it.args.first}**")
-        }
-    }
-    
-    command("toggleParty") {
-        description = "Toggles party mode"
-        execute {
-            botConfiguration.partyMode = !botConfiguration.partyMode
-            persistenceService.save(botConfiguration)
-            it.respond("${if(botConfiguration.partyMode) "Let's get this party started!" else "We're done. That's all folks!"}")
-        }
-    }
-    
-    command("getPartySuffix") {
-        description = "Display current party mode suffix"
-        execute {
-            it.respond("Suffix: ${botConfiguration.partySuffix}")
-        }
-    }
-    
-    command("setPartySuffix") {
-        description = "Set new party mode suffix"
-        execute (EveryArg("Suffix")){
-            val symbol = it.args.first.replace("\uD83D\uDD28", "")
-            if (symbol.length > 11 || symbol.isEmpty()) {
-                it.respond("Suffix is must be shorter than 11 characters and not empty!")
-            } else {
-                botConfiguration.partySuffix = "$symbol "
-                botConfiguration.partyStrip = symbol
-                persistenceService.save(botConfiguration)
-                it.respond("Set the party suffix to **${symbol}**")
-            }
-        }
-    }
 }

--- a/src/main/kotlin/me/aberrantfox/hawk/commands/ConfigurationCommands.kt
+++ b/src/main/kotlin/me/aberrantfox/hawk/commands/ConfigurationCommands.kt
@@ -1,0 +1,56 @@
+package me.aberrantfox.hawk.commands
+
+import me.aberrantfox.hawk.configuration.BotConfiguration
+import me.jakejmattson.discordkt.api.annotations.CommandSet
+import me.jakejmattson.discordkt.api.arguments.*
+import me.jakejmattson.discordkt.api.dsl.command.commands
+
+@CommandSet("Config")
+fun createConfigCommands(botConfiguration: BotConfiguration) = commands {
+    command("setMode") {
+        description = "Set the mode to prefix or suffix"
+        execute(ChoiceArg("mode", "prefix", "suffix")) {
+            botConfiguration.mode = it.args.first
+            botConfiguration.save()
+            it.respond("Set the bots nickname mode to **${it.args.first}**.")
+        }
+    }
+
+    command("setSymbol") {
+        description = "Set the token to appear in nicknames."
+        execute(AnyArg("Symbol")) {
+            val symbol = it.args.first
+            botConfiguration.nickSymbol = "$symbol "
+            botConfiguration.stripString = symbol
+            botConfiguration.save()
+            it.respond("Set the bots symbol to **${it.args.first}**")
+        }
+    }
+
+    command("setRole") {
+        description = "Set the role that will have symbols enforced."
+        execute(RoleArg) {
+            botConfiguration.staffRole = it.args.first.name
+            botConfiguration.save()
+            it.respond("Set the bots role to **${it.args.first.name}**")
+        }
+    }
+
+    command("setOwner") {
+        description = "Set the owner & admin of the bot."
+        execute(MemberArg) {
+            botConfiguration.owner = it.args.first.id
+            botConfiguration.save()
+            it.respond("Set the bots owner to **${it.args.first.user.asTag}**")
+        }
+    }
+
+    command("setPrefix") {
+        description = "Set the bot's invocation prefix"
+        execute(AnyArg("Prefix")) {
+            botConfiguration.botPrefix = it.args.first
+            botConfiguration.save()
+            it.respond("Set the bots owner prefix to **${it.args.first}**")
+        }
+    }
+}

--- a/src/main/kotlin/me/aberrantfox/hawk/commands/PartyModeCommands.kt
+++ b/src/main/kotlin/me/aberrantfox/hawk/commands/PartyModeCommands.kt
@@ -1,0 +1,40 @@
+package me.aberrantfox.hawk.commands
+
+import me.aberrantfox.hawk.configuration.BotConfiguration
+import me.jakejmattson.discordkt.api.annotations.CommandSet
+import me.jakejmattson.discordkt.api.arguments.*
+import me.jakejmattson.discordkt.api.dsl.command.commands
+
+@CommandSet("Party")
+fun createPartymodeCommands(botConfiguration: BotConfiguration) = commands {
+    command("toggleParty") {
+        description = "Toggles party mode"
+        execute {
+            botConfiguration.partyMode = !botConfiguration.partyMode
+            botConfiguration.save()
+            it.respond(if(botConfiguration.partyMode) "Let's get this party started!" else "We're done. That's all folks!")
+        }
+    }
+
+    command("getPartySuffix") {
+        description = "Display current party mode suffix"
+        execute {
+            it.respond("Suffix: ${botConfiguration.partySuffix}")
+        }
+    }
+
+    command("setPartySuffix") {
+        description = "Set new party mode suffix"
+        execute (EveryArg("Suffix")){
+            val symbol = it.args.first.replace("\uD83D\uDD28", "")
+            if (symbol.length > 11 || symbol.isEmpty()) {
+                it.respond("Suffix is must be shorter than 11 characters and not empty!")
+            } else {
+                botConfiguration.partySuffix = "$symbol "
+                botConfiguration.partyStrip = symbol
+                botConfiguration.save()
+                it.respond("Set the party suffix to **${symbol}**")
+            }
+        }
+    }
+}

--- a/src/main/kotlin/me/aberrantfox/hawk/configuration/BotConfiguration.kt
+++ b/src/main/kotlin/me/aberrantfox/hawk/configuration/BotConfiguration.kt
@@ -1,8 +1,7 @@
 package me.aberrantfox.hawk.configuration
 
-import me.aberrantfox.kjdautils.api.annotation.Data
+import me.jakejmattson.discordkt.api.dsl.data.Data
 
-@Data("data/configuration.json")
 data class BotConfiguration(
         val guild: String = "<insert-guild>",
         var owner: String = "<insert-id>",
@@ -15,4 +14,4 @@ data class BotConfiguration(
         var partyMode: Boolean = false,
         var partySuffix: String = "\ud83e\udd73 ",
         var partyStrip: String = "\ud83e\udd73"
-)
+): Data("data/configuration.json")

--- a/src/main/kotlin/me/aberrantfox/hawk/extensions/jda/GuildMemberExtensions.kt
+++ b/src/main/kotlin/me/aberrantfox/hawk/extensions/jda/GuildMemberExtensions.kt
@@ -3,9 +3,9 @@ package me.aberrantfox.hawk.extensions.jda
 import me.aberrantfox.hawk.configuration.BotConfiguration
 import me.aberrantfox.hawk.botdata.Messages
 import me.aberrantfox.hawk.extensions.stdlib.inject
-import me.aberrantfox.kjdautils.extensions.jda.fullName
-import me.aberrantfox.kjdautils.extensions.jda.getHighestRole
-import me.aberrantfox.kjdautils.extensions.jda.sendPrivateMessage
+import me.jakejmattson.discordkt.api.extensions.jda.fullName
+import me.jakejmattson.discordkt.api.extensions.jda.getHighestRole
+import me.jakejmattson.discordkt.api.extensions.jda.sendPrivateMessage
 import net.dv8tion.jda.api.entities.Guild
 import net.dv8tion.jda.api.entities.Member
 

--- a/src/main/kotlin/me/aberrantfox/hawk/listeners/OtherEventCatcher.kt
+++ b/src/main/kotlin/me/aberrantfox/hawk/listeners/OtherEventCatcher.kt
@@ -5,7 +5,7 @@ import me.aberrantfox.hawk.configuration.BotConfiguration
 import me.aberrantfox.hawk.botdata.Messages
 import me.aberrantfox.hawk.extensions.jda.ensureCorrectEffectiveName
 import me.aberrantfox.hawk.extensions.jda.ensureCorrectEffectivePartyName
-import me.aberrantfox.kjdautils.extensions.jda.toMember
+import me.jakejmattson.discordkt.api.extensions.jda.toMember
 import net.dv8tion.jda.api.events.guild.member.GuildMemberJoinEvent
 import net.dv8tion.jda.api.events.guild.member.GuildMemberRoleAddEvent
 import net.dv8tion.jda.api.events.guild.member.GuildMemberRoleRemoveEvent

--- a/src/main/kotlin/me/aberrantfox/hawk/preconditions/IsOwnerPrecondition.kt
+++ b/src/main/kotlin/me/aberrantfox/hawk/preconditions/IsOwnerPrecondition.kt
@@ -1,12 +1,17 @@
 package me.aberrantfox.hawk.preconditions
 
 import me.aberrantfox.hawk.configuration.BotConfiguration
-import me.aberrantfox.kjdautils.api.annotation.Precondition
-import me.aberrantfox.kjdautils.internal.command.Fail
-import me.aberrantfox.kjdautils.internal.command.Pass
-import me.aberrantfox.kjdautils.internal.command.precondition
+import me.jakejmattson.discordkt.api.dsl.preconditions.Precondition
+import me.jakejmattson.discordkt.api.dsl.command.CommandEvent
+import me.jakejmattson.discordkt.api.dsl.preconditions.Fail
+import me.jakejmattson.discordkt.api.dsl.preconditions.Pass
+import me.jakejmattson.discordkt.api.dsl.preconditions.PreconditionResult
 
-@Precondition
-fun isOwner(configuration: BotConfiguration) = precondition { event ->
-    if(event.author.id != configuration.owner) Fail("Commands can only be used by the bot owner.") else Pass
+class isOwnerPrecondition(private val configuration: BotConfiguration): Precondition() {
+    override fun evaluate(event: CommandEvent<*>): PreconditionResult {
+        if(event.author.id != configuration.owner) {
+            return Fail("Commands can only be used by the bot owner.")
+        }
+        return Pass
+    }
 }

--- a/src/main/resources/properties.json
+++ b/src/main/resources/properties.json
@@ -1,6 +1,6 @@
 {
   "author": "${project.author}",
   "version": "${version}",
-  "kutils": "${kutils.version}",
+  "discordKt": "${discordKt.version}",
   "repository": "${project.repository}"
 }


### PR DESCRIPTION
# feat: change to discordkt, split commands

- Switch to DiscordKt and handle migration and updates needed to move from KUtils.
- Split commands over multiple files to clean up help menu.
- Add party mode suffix to configuration embed.