### PR TITLE
feat: partymode channel filtering

### DIFF
--- a/commands.md
+++ b/commands.md
@@ -21,11 +21,13 @@
 | setSymbol | Symbol    | Set the token to appear in nicknames.         |
 
 ## Party
-| Commands       | Arguments | Description                       |
-| -------------- | --------- | --------------------------------- |
-| getPartySuffix |           | Display current party mode suffix |
-| setPartySuffix | Suffix    | Set new party mode suffix         |
-| toggleParty    |           | Toggles party mode                |
+| Commands            | Arguments                    | Description                                     |
+| ------------------- | ---------------------------- | ----------------------------------------------- |
+| getPartySuffix      |                              | Display current party mode suffix               |
+| partyChannels       | add/rem/list, (Text Channel) | Add, remove or view channels used in party mode |
+| setPartySuffix      | Suffix                       | Set new party mode suffix                       |
+| toggleParty         |                              | Toggles party mode                              |
+| togglePartyChannels |                              | Toggle channel based filtering for party mode   |
 
 ## Utility
 | Commands | Arguments | Description          |

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.example</groupId>
     <artifactId>Hawk</artifactId>
-    <version>1.3.4</version>
+    <version>1.3.5</version>
 
     <properties>
         <kotlin.version>1.3.71</kotlin.version>

--- a/src/main/kotlin/me/aberrantfox/hawk/configuration/BotConfiguration.kt
+++ b/src/main/kotlin/me/aberrantfox/hawk/configuration/BotConfiguration.kt
@@ -14,5 +14,7 @@ data class BotConfiguration(
         var mode: String = "suffix",
         var partyMode: Boolean = false,
         var partySuffix: String = "\ud83e\udd73 ",
-        var partyStrip: String = "\ud83e\udd73"
+        var partyStrip: String = "\ud83e\udd73",
+        var partyModeChannels: MutableList<String> = mutableListOf(),
+        var partyModeChannelFilter: Boolean = false
 ): Data("data/configuration.json")

--- a/src/main/kotlin/me/aberrantfox/hawk/extensions/jda/GuildMemberExtensions.kt
+++ b/src/main/kotlin/me/aberrantfox/hawk/extensions/jda/GuildMemberExtensions.kt
@@ -8,6 +8,7 @@ import me.jakejmattson.discordkt.api.extensions.jda.getHighestRole
 import me.jakejmattson.discordkt.api.extensions.jda.sendPrivateMessage
 import net.dv8tion.jda.api.entities.Guild
 import net.dv8tion.jda.api.entities.Member
+import net.dv8tion.jda.api.entities.TextChannel
 
 fun Member.isStaffMember(guild: Guild, configuration: BotConfiguration) =
         roles.any { it.name == configuration.staffRole } || isOwner
@@ -65,12 +66,20 @@ fun Member.ensureHammer(configuration: BotConfiguration, selfMember: Member, mes
     }
 }
 
-fun Member.ensureCorrectEffectivePartyName(guild: Guild, configuration: BotConfiguration, messages: Messages, action: (Member) -> Unit = {}) {
+fun Member.ensureCorrectEffectivePartyName(guild: Guild, configuration: BotConfiguration, messages: Messages, channel: TextChannel, action: (Member) -> Unit = {}) {
     if (!(configuration.enabled)) {
         return
     }
 
     if (this.id == guild.selfMember.id) {
+        return
+    }
+
+    if (isHigherThan(guild.selfMember)) {
+        return
+    }
+
+    if (configuration.partyModeChannelFilter && !configuration.partyModeChannels.contains(channel.id)) {
         return
     }
     

--- a/src/main/kotlin/me/aberrantfox/hawk/listeners/OtherEventCatcher.kt
+++ b/src/main/kotlin/me/aberrantfox/hawk/listeners/OtherEventCatcher.kt
@@ -27,7 +27,7 @@ class OtherEventCatcher(val configuration: BotConfiguration, val messages: Messa
 
     @Subscribe
     fun onGuildMessageEvent(event: GuildMessageReceivedEvent) {
-        event.member?.ensureCorrectEffectivePartyName(event.guild, configuration, messages)
+        event.member?.ensureCorrectEffectivePartyName(event.guild, configuration, messages, event.channel)
         event.member?.ensureCorrectEffectiveName(event.guild, configuration, messages)
     }
 


### PR DESCRIPTION
# feat: partymode channel filtering
Add the ability to restrict party mode to a specific channel, or set of channels.

Added:
- Configuration options to save channels that party mode should operate in.
- Commands to add, remove and list these channels.
- Command to toggle the channel filtering.
- Logic in the party mode handler to ignore events in a given channel if the filter is active and that channel is included
- Fixed exception when user has higher role than the bot.