### PR TITLE
feat: add symbol blacklist functionality

### DIFF
--- a/commands.md
+++ b/commands.md
@@ -13,12 +13,13 @@
 | setAdminRole | Role      | Set the admin role for the bot. |
 
 ## Config
-| Commands  | Arguments | Description                                   |
-| --------- | --------- | --------------------------------------------- |
-| setMode   | mode      | Set the mode to prefix or suffix              |
-| setPrefix | Prefix    | Set the bot's invocation prefix               |
-| setRole   | Role      | Set the role that will have symbols enforced. |
-| setSymbol | Symbol    | Set the token to appear in nicknames.         |
+| Commands  | Arguments              | Description                                   |
+| --------- | ---------------------- | --------------------------------------------- |
+| blacklist | add/rem/list, (symbol) | Add a symbol to the symbol blacklist.         |
+| setMode   | mode                   | Set the mode to prefix or suffix              |
+| setPrefix | Prefix                 | Set the bot's invocation prefix               |
+| setRole   | Role                   | Set the role that will have symbols enforced. |
+| setSymbol | Symbol                 | Set the token to appear in nicknames.         |
 
 ## Party
 | Commands            | Arguments                    | Description                                     |

--- a/src/main/kotlin/me/aberrantfox/hawk/commands/ConfigurationCommands.kt
+++ b/src/main/kotlin/me/aberrantfox/hawk/commands/ConfigurationCommands.kt
@@ -4,6 +4,8 @@ import me.aberrantfox.hawk.configuration.BotConfiguration
 import me.jakejmattson.discordkt.api.annotations.CommandSet
 import me.jakejmattson.discordkt.api.arguments.*
 import me.jakejmattson.discordkt.api.dsl.command.commands
+import me.jakejmattson.discordkt.api.dsl.embed.embed
+import net.dv8tion.jda.api.entities.MessageEmbed
 
 @CommandSet("Config")
 fun createConfigCommands(botConfiguration: BotConfiguration) = commands {
@@ -42,6 +44,46 @@ fun createConfigCommands(botConfiguration: BotConfiguration) = commands {
             botConfiguration.botPrefix = it.args.first
             botConfiguration.save()
             it.respond("Set the bots owner prefix to **${it.args.first}**")
+        }
+    }
+
+    command("blacklist") {
+        description = "Add a symbol to the symbol blacklist."
+        execute(ChoiceArg("add/rem/list", "add", "rem", "view"),
+            AnyArg("symbol").makeNullableOptional(null)) {
+            val(choice, symbol) = it.args
+            when(choice) {
+                "add" -> {
+                    if (botConfiguration.disallowedSymbols.contains(symbol)) {
+                        it.respond("${it.args.first} is already blacklisted")
+                        return@execute
+                    }
+                    botConfiguration.disallowedSymbols.add(symbol!!.replace(" ", ""))
+                    botConfiguration.save()
+                    it.respond("Added **${symbol}** to blacklist.")
+                }
+
+                "rem" -> {
+                    if (!botConfiguration.disallowedSymbols.contains(symbol)) {
+                        it.respond("${it.args.first} is not blacklisted")
+                        return@execute
+                    }
+                    botConfiguration.disallowedSymbols.remove(symbol!!.replace(" ", ""))
+                    botConfiguration.save()
+                    it.respond("Removed **${symbol}** from blacklist.")
+
+                }
+
+                "view" -> {
+                    it.respond(embed {
+                        color = infoColor
+                        addField("**Blacklisted Symbols**", botConfiguration.disallowedSymbols.joinToString(" , ") )
+                    })
+                }
+                else -> {
+                    it.respond("Invalid choice")
+                }
+            }
         }
     }
 }

--- a/src/main/kotlin/me/aberrantfox/hawk/configuration/BotConfiguration.kt
+++ b/src/main/kotlin/me/aberrantfox/hawk/configuration/BotConfiguration.kt
@@ -11,6 +11,7 @@ data class BotConfiguration(
         var enabled: Boolean = true,
         var staffRole: String = "Staff",
         var stripString: String = "\uD83D\uDD28",
+        var disallowedSymbols: MutableList<String> = mutableListOf(),
         var mode: String = "suffix",
         var partyMode: Boolean = false,
         var partySuffix: String = "\ud83e\udd73 ",

--- a/src/main/kotlin/me/aberrantfox/hawk/extensions/jda/GuildMemberExtensions.kt
+++ b/src/main/kotlin/me/aberrantfox/hawk/extensions/jda/GuildMemberExtensions.kt
@@ -29,10 +29,6 @@ fun Member.isHigherThan(other: Member): Boolean {
 }
 
 fun Member.ensureNoHammer(configuration: BotConfiguration, selfMember: Member, action: (Member) -> Unit = {}) {
-//    if (!(effectiveName.contains(configuration.stripString))) {
-//        return
-//    }
-
     if(!configuration.disallowedSymbols.any { effectiveName.contains(it) }) {
         return
     }

--- a/src/main/kotlin/me/aberrantfox/hawk/extensions/jda/GuildMemberExtensions.kt
+++ b/src/main/kotlin/me/aberrantfox/hawk/extensions/jda/GuildMemberExtensions.kt
@@ -87,7 +87,6 @@ fun Member.ensureCorrectEffectivePartyName(guild: Guild, configuration: BotConfi
 }
 
 fun Member.ensureCorrectEffectiveName(guild: Guild, configuration: BotConfiguration, messages: Messages, action: (Member) -> Unit = {}) {
-    println("fired")
     if (!(configuration.enabled)) {
         return
     }

--- a/src/main/kotlin/me/aberrantfox/hawk/extensions/jda/GuildMemberExtensions.kt
+++ b/src/main/kotlin/me/aberrantfox/hawk/extensions/jda/GuildMemberExtensions.kt
@@ -29,7 +29,11 @@ fun Member.isHigherThan(other: Member): Boolean {
 }
 
 fun Member.ensureNoHammer(configuration: BotConfiguration, selfMember: Member, action: (Member) -> Unit = {}) {
-    if (!(effectiveName.contains(configuration.stripString))) {
+//    if (!(effectiveName.contains(configuration.stripString))) {
+//        return
+//    }
+
+    if(!configuration.disallowedSymbols.any { effectiveName.contains(it) }) {
         return
     }
 
@@ -87,6 +91,7 @@ fun Member.ensureCorrectEffectivePartyName(guild: Guild, configuration: BotConfi
 }
 
 fun Member.ensureCorrectEffectiveName(guild: Guild, configuration: BotConfiguration, messages: Messages, action: (Member) -> Unit = {}) {
+    println("fired")
     if (!(configuration.enabled)) {
         return
     }
@@ -110,7 +115,7 @@ fun Member.setPartySuffix(configuration: BotConfiguration) {
             println("Added party suffix for ${this.fullName()}")
         }
     } else if (!configuration.partyMode && userPartying){
-        val nick = removeNickPrefix(effectiveName, configuration.partyStrip)
+        val nick = removeNickPrefix(effectiveName, mutableListOf(configuration.partyStrip))
         modifyNickname(nick).queue {
             println("Removed party suffix for ${this.fullName()}")
         }
@@ -121,7 +126,7 @@ fun Member.determineNewNickName(configuration: BotConfiguration) =
         if (isStaffMember(guild, configuration)) {
             applyNickPrefix(effectiveName, configuration.nickSymbol, configuration.stripString, configuration.mode)
         } else {
-            removeNickPrefix(effectiveName, configuration.stripString)
+            removeNickPrefix(effectiveName, configuration.disallowedSymbols)
         }
 
 fun applyNickPrefix(name: String, symbol: String, stripString: String, mode: String): String {
@@ -151,13 +156,19 @@ fun applyNickPrefix(name: String, symbol: String, stripString: String, mode: Str
     }
 }
 
-fun removeNickPrefix(name: String, prefix: String): String {
-    val strippedName = name.replace(prefix, "")
+fun removeNickPrefix(name: String, disallowedSymbols: MutableList<String>): String {
+    var strippedName = name
+
+    for (symbol in disallowedSymbols) {
+        strippedName = strippedName.replace(symbol, "")
+        println(symbol)
+        println("$name $strippedName")
+    }
 
     return if (strippedName.isBlank() || strippedName == "") {
         "Chunck Testa"
     } else {
-        name.replace(prefix, "")
+        strippedName
     }
 }
 


### PR DESCRIPTION
Add ability to blacklist symbols that can't be a part of a user's nickname.

Added:
- New `blacklist` command to add / remove / view the blacklist.
- Updated naming logic to remove any blacklisted symbols from names.