### PR TITLE
fix: add correct argument to bot responses

### DIFF
--- a/src/main/kotlin/me/aberrantfox/hawk/commands/ConfigurationCommands.kt
+++ b/src/main/kotlin/me/aberrantfox/hawk/commands/ConfigurationCommands.kt
@@ -55,7 +55,7 @@ fun createConfigCommands(botConfiguration: BotConfiguration) = commands {
             when(choice) {
                 "add" -> {
                     if (botConfiguration.disallowedSymbols.contains(symbol)) {
-                        it.respond("${it.args.first} is already blacklisted")
+                        it.respond("${symbol} is already blacklisted")
                         return@execute
                     }
                     botConfiguration.disallowedSymbols.add(symbol!!.replace(" ", ""))
@@ -65,7 +65,7 @@ fun createConfigCommands(botConfiguration: BotConfiguration) = commands {
 
                 "rem" -> {
                     if (!botConfiguration.disallowedSymbols.contains(symbol)) {
-                        it.respond("${it.args.first} is not blacklisted")
+                        it.respond("${symbol} is not blacklisted")
                         return@execute
                     }
                     botConfiguration.disallowedSymbols.remove(symbol!!.replace(" ", ""))


### PR DESCRIPTION
# fix: add correct argument to bot responses

Update the bot response when a symbol is already blacklisted, or when a symbol is removed from the blacklist to include the symbol.