### PR TITLE
fix: update choicearg name for blacklist command

### DIFF
--- a/src/main/kotlin/me/aberrantfox/hawk/commands/ConfigurationCommands.kt
+++ b/src/main/kotlin/me/aberrantfox/hawk/commands/ConfigurationCommands.kt
@@ -49,7 +49,7 @@ fun createConfigCommands(botConfiguration: BotConfiguration) = commands {
 
     command("blacklist") {
         description = "Add a symbol to the symbol blacklist."
-        execute(ChoiceArg("add/rem/list", "add", "rem", "view"),
+        execute(ChoiceArg("add/rem/view", "add", "rem", "view"),
             AnyArg("symbol").makeNullableOptional(null)) {
             val(choice, symbol) = it.args
             when(choice) {


### PR DESCRIPTION
# fix: update choicearg name for blacklist command

Update the name for the ChoiceArg in the blacklist command to match the expected argument.