### PR TITLE
fix: add cache service to load data to the bot on startup

### DIFF
--- a/src/main/kotlin/me/ddivad/hawk/Main.kt
+++ b/src/main/kotlin/me/ddivad/hawk/Main.kt
@@ -1,6 +1,7 @@
 package me.ddivad.hawk
 
 import dev.kord.common.annotation.KordPreview
+import dev.kord.core.supplier.EntitySupplyStrategy
 import dev.kord.gateway.Intent
 import dev.kord.gateway.Intents
 import dev.kord.gateway.PrivilegedIntent
@@ -32,6 +33,7 @@ suspend fun main() {
             allowMentionPrefix = true
             commandReaction = null
             theme = Color.MAGENTA
+            entitySupplyStrategy = EntitySupplyStrategy.cacheWithRestFallback
             permissions = Permissions
             intents = Intents(
                 Intent.GuildMembers

--- a/src/main/kotlin/me/ddivad/hawk/services/CacheService.kt
+++ b/src/main/kotlin/me/ddivad/hawk/services/CacheService.kt
@@ -1,0 +1,21 @@
+package me.ddivad.hawk.services
+
+import dev.kord.core.supplier.EntitySupplyStrategy
+import kotlinx.coroutines.flow.toList
+import me.ddivad.hawk.dataclasses.Configuration
+import me.jakejmattson.discordkt.Discord
+import me.jakejmattson.discordkt.annotations.Service
+
+@Service
+class CacheService(private val discord: Discord, private val configuration: Configuration) {
+    suspend fun run() {
+        configuration.guildConfigurations.forEach { config ->
+            try {
+                val guild = config.value.id.let { discord.kord.getGuild(it) } ?: return@forEach
+                val roles = guild.withStrategy(EntitySupplyStrategy.cachingRest).roles.toList()
+            } catch (ex: Exception) {
+                println(ex.message)
+            }
+        }
+    }
+}


### PR DESCRIPTION
# fix: add cache service to load data to the bot on startup

- Add cache strategy to load all guild roles into the bot on startup
- Change entity supply strategy