### PR TITLE
feat: add party modes

### DIFF
--- a/commands.md
+++ b/commands.md
@@ -19,7 +19,7 @@
 | getPartySymbol     |                                    | View the current party mode symbol              |
 | partyChannelFilter | PartyChannelOption, [PartyChannel] | Add, remove or view channels used in party mode |
 | setPartySymbol     | Suffix                             | Set new party mode symbol                       |
-| toggleParty        |                                    | Toggles party mode                              |
+| toggleParty        | Mode                               | Toggles party mode                              |
 
 ## Nickname
 | Commands  | Arguments                         | Description                           |

--- a/src/main/kotlin/me/ddivad/hawk/commands/PartyModeCommands.kt
+++ b/src/main/kotlin/me/ddivad/hawk/commands/PartyModeCommands.kt
@@ -16,10 +16,16 @@ fun partyModeCommands(configuration: Configuration) = subcommand("Party") {
         }
     }
 
-    sub("toggleParty", "Toggles party mode") {
-        execute {
+    sub("toggleParty", "Toggles party mode",  ) {
+        execute(ChoiceArg("Mode", "choose a party mode", "Symbol","Furry")) {
+            val choice = args.first
             val guildConfiguration = configuration[guild.id] ?: return@execute
 
+            if (choice == "Symbol") {
+                guildConfiguration.partyModeConfiguration.mode = "Symbol"
+            } else {
+                guildConfiguration.partyModeConfiguration.mode = "Furry"
+            }
             guildConfiguration.partyModeConfiguration.enabled = !guildConfiguration.partyModeConfiguration.enabled
             configuration.save()
             respondPublic(

--- a/src/main/kotlin/me/ddivad/hawk/dataclasses/Configuration.kt
+++ b/src/main/kotlin/me/ddivad/hawk/dataclasses/Configuration.kt
@@ -54,7 +54,8 @@ data class PartyModeConfiguration(
     var symbol: String = "",
     var symbolStrip: String = "",
     var channels: MutableList<Snowflake> = mutableListOf(),
-    var channelFilterEnabled: Boolean = false
+    var channelFilterEnabled: Boolean = false,
+    var mode: String = ""
 )
 
 @Serializable

--- a/src/main/kotlin/me/ddivad/hawk/embeds/GuildEmbeds.kt
+++ b/src/main/kotlin/me/ddivad/hawk/embeds/GuildEmbeds.kt
@@ -28,6 +28,7 @@ suspend fun EmbedBuilder.createConfigurationEmbed(configuration: Configuration, 
     field {
         name = "**Party**"
         value = "Enabled: ${guildConfiguration.partyModeConfiguration.enabled}\n" +
+                "Mode: ${guildConfiguration.partyModeConfiguration.mode}\n" +
                 "Symbol: ${guildConfiguration.partyModeConfiguration.symbol}\n" +
                 "Channel Filter Enabled: ${guildConfiguration.partyModeConfiguration.channelFilterEnabled}\n" +
                 "Party Channels: ${

--- a/src/main/kotlin/me/ddivad/hawk/services/NicknameService.kt
+++ b/src/main/kotlin/me/ddivad/hawk/services/NicknameService.kt
@@ -11,6 +11,14 @@ import me.jakejmattson.discordkt.annotations.Service
 class NicknameService(private val configuration: Configuration, private val loggingService: LoggingService) {
     suspend fun setOrRemovePartyNickname(guild: Guild, member: Member, channel: TextChannel) {
         val partyConfiguration = configuration[guild.id]?.partyModeConfiguration ?: return
+        if (member.isBot) {
+            return
+        }
+        if (partyConfiguration.mode == "Furry" && (!furryNames.contains(member.displayName) || !furryNames.contains(member.nickname))) {
+            val nickname = furryNames.random()
+            changeMemberNickname(guild, member, nickname)
+            return
+        }
 
         if (partyConfiguration.symbol.isNullOrBlank()) {
             return

--- a/src/main/resources/bot.properties
+++ b/src/main/resources/bot.properties
@@ -1,4 +1,4 @@
-#Sat Apr 01 00:39:14 IST 2023
+#Sat Apr 01 01:05:01 IST 2023
 name=Hawk
 description=A bot to add and maintain a symbol as a prefix or suffix in staff names.\n
 version=3.0.0-RC1


### PR DESCRIPTION
# feat: add party modes

Add a new way to create a party with a `mode` parameter. This PR adds a furry mode, as well as the traditional symbol mode.