### PR TITLE
feat: add a way to reset party mode names

### DIFF
--- a/src/main/kotlin/me/ddivad/hawk/commands/NicknameCommands.kt
+++ b/src/main/kotlin/me/ddivad/hawk/commands/NicknameCommands.kt
@@ -24,10 +24,10 @@ fun nicknameCommands(configuration: Configuration, loggingService: LoggingServic
 
             var newNickname = member.displayName
             if (theme == "Furry") {
-                var firstPart = "${nicknameService.furryNames.random()}"
-                var secondPart = "${nicknameService.furryNames.random()}"
+                var firstPart = nicknameService.furryNames.random()
+                var secondPart = nicknameService.furryNames.random()
                 while (firstPart == secondPart) {
-                    secondPart = "${nicknameService.furryNames.random()}"
+                    secondPart = nicknameService.furryNames.random()
                 }
                 newNickname = "$firstPart $secondPart"
             } else if (theme == "Manual" && nickname != null) {

--- a/src/main/kotlin/me/ddivad/hawk/commands/PartyModeCommands.kt
+++ b/src/main/kotlin/me/ddivad/hawk/commands/PartyModeCommands.kt
@@ -29,7 +29,7 @@ fun partyModeCommands(configuration: Configuration) = subcommand("Party") {
             guildConfiguration.partyModeConfiguration.enabled = !guildConfiguration.partyModeConfiguration.enabled
             configuration.save()
             respondPublic(
-                if (guildConfiguration.partyModeConfiguration.enabled) "Let's get this party started! ${guildConfiguration.partyModeConfiguration.symbol}"
+                if (guildConfiguration.partyModeConfiguration.enabled) "Let's get this party started!  ${if (guildConfiguration.partyModeConfiguration.mode == "Symbol") guildConfiguration.partyModeConfiguration.symbol else ""}"
                 else "We're done. That's all folks!"
             )
         }

--- a/src/main/kotlin/me/ddivad/hawk/services/NicknameService.kt
+++ b/src/main/kotlin/me/ddivad/hawk/services/NicknameService.kt
@@ -32,18 +32,20 @@ class NicknameService(private val configuration: Configuration, private val logg
             }
         }
 
-        if (partyConfiguration.mode == "Furry" && !furryNames.containsAll(member.displayName.split(" "))) {
-            if (!partyConfiguration.enabled) {
+        if (partyConfiguration.mode == "Furry") {
+           if (partyConfiguration.enabled && !furryNames.containsAll(member.displayName.split(" "))) {
+                val firstPart = furryNames.random()
+                var secondPart = furryNames.random()
+                while (firstPart == secondPart) {
+                    secondPart = furryNames.random()
+                }
+                val nickname = "$firstPart $secondPart"
+                changeMemberNickname(guild, member, nickname)
                 return
-            }
-            var firstPart = "${furryNames.random()}"
-            var secondPart = "${furryNames.random()}"
-            while (firstPart == secondPart) {
-                secondPart = "${furryNames.random()}"
-            }
-            val nickname = "$firstPart $secondPart"
-            changeMemberNickname(guild, member, nickname)
-            return
+            } else if (!partyConfiguration.enabled && furryNames.containsAll(member.displayName.split(" "))) {
+               changeMemberNickname(guild, member, member.username)
+               return
+           }
         }
     }
 


### PR DESCRIPTION
# feat: add a way to reset party mode names

Add a way to reset a member's nickname when party mode is disabled. Will revert back to their username, stripping the party mode theme name.