### PR TITLE
feat: allow reaction roles to only allow 1 role choice

### DIFF
--- a/commands.md
+++ b/commands.md
@@ -28,9 +28,9 @@
 | nick      | LowerMemberArg, Theme, [Nickname] | Set a member's nickname               |
 
 ## ReactionRole
-| Commands           | Arguments               | Description                  |
-|--------------------|-------------------------|------------------------------|
-| createReactionRole | Roles, EmbedDescription | Create a reaction role embed |
+| Commands           | Arguments                                | Description                  |
+|--------------------|------------------------------------------|------------------------------|
+| createReactionRole | Roles, EmbedDescription, [AllowMultiple] | Create a reaction role embed |
 
 ## Utility
 | Commands | Arguments | Description          |

--- a/src/main/kotlin/me/ddivad/hawk/dataclasses/Configuration.kt
+++ b/src/main/kotlin/me/ddivad/hawk/dataclasses/Configuration.kt
@@ -75,5 +75,6 @@ data class ReactionRole(
     val description: String,
     val roles: MutableList<Snowflake>,
     var messageId: Snowflake?,
-    val channel: Snowflake
+    val channel: Snowflake,
+    val allowMultiple: Boolean = true
 )

--- a/src/main/kotlin/me/ddivad/hawk/embeds/ReactionRole.kt
+++ b/src/main/kotlin/me/ddivad/hawk/embeds/ReactionRole.kt
@@ -23,12 +23,19 @@ suspend fun MenuBuilder.createReactionRoleMenu(discord: Discord, guild: Guild, r
     }
     buttons {
         runBlocking {
-            reactionRole.roles.forEach {
-                val liveRole = guild.getRole(it)
+            reactionRole.roles.forEach { role ->
+                val liveRole = guild.getRole(role)
 
                 actionButton(liveRole.name, null) {
                     val member = guild.getMemberOrNull(this.user.id) ?: return@actionButton
-                    if (!member.roles.toList().contains(liveRole)) {
+                    if (!member.roleIds.contains(role)) {
+                        if (!reactionRole.allowMultiple) {
+                            reactionRole.roles.forEach { role ->
+                                if (member.roleIds.contains(role)) {
+                                    member.removeRole(role)
+                                }
+                            }
+                        }
                         member.addRole(liveRole.id, "Reaction button clicked")
                         respondEphemeral { content = "Assigned role ${liveRole.name}" }
                         loggingService.reactionRoleAdded(guild, member, liveRole)

--- a/src/main/kotlin/me/ddivad/hawk/services/StartupService.kt
+++ b/src/main/kotlin/me/ddivad/hawk/services/StartupService.kt
@@ -1,6 +1,7 @@
 package me.ddivad.hawk.services
 
 import dev.kord.core.behavior.getChannelOfOrNull
+import dev.kord.core.entity.channel.GuildMessageChannel
 import dev.kord.core.entity.channel.TextChannel
 import me.ddivad.hawk.dataclasses.Configuration
 import me.ddivad.hawk.embeds.createReactionRoleMenu
@@ -29,7 +30,7 @@ class StartupService(
             }
 
             guildConfig.reactionRoles.forEach {
-                val channel = guild.getChannelOfOrNull<TextChannel>(it.channel) ?: return
+                val channel = guild.getChannelOfOrNull<GuildMessageChannel>(it.channel) ?: return
                 val message = channel.getMessageOrNull(it.messageId!!) ?: return
                 logger.info {
                     buildGuildLogMessage(

--- a/src/main/resources/bot.properties
+++ b/src/main/resources/bot.properties
@@ -1,5 +1,5 @@
-#Sat Apr 01 18:01:31 IST 2023
+#Fri Mar 29 00:53:13 GMT 2024
 name=Hawk
 description=A bot to add and maintain a symbol as a prefix or suffix in staff names.\n
-version=3.0.0-RC1
+version=3.1
 url=https\://github.com/the-programmers-hangout/Hawk/


### PR DESCRIPTION
# feat: allow reaction roles to only allow 1 role choice

Update the `/createReactionRole` command to add a new argument - `allowMultiple`. This defaults to true and is optional, but lets you set it to false to allow a reaction role menu to only allow 1 role choice.

