### PR TITLE
chore: miscellaneous refactoring to cleanup code

### DIFF
--- a/src/main/kotlin/me/ddivad/hawk/commands/ReactionRoleCommands.kt
+++ b/src/main/kotlin/me/ddivad/hawk/commands/ReactionRoleCommands.kt
@@ -5,14 +5,10 @@ import me.ddivad.hawk.dataclasses.Permissions
 import me.ddivad.hawk.dataclasses.ReactionRole
 import me.ddivad.hawk.embeds.createReactionRoleMenu
 import me.ddivad.hawk.services.LoggingService
-import me.ddivad.hawk.services.buildGuildLogMessage
 import me.jakejmattson.discordkt.arguments.EveryArg
 import me.jakejmattson.discordkt.commands.commands
 import me.jakejmattson.discordkt.dsl.edit
 import me.jakejmattson.discordkt.extensions.toSnowflake
-import mu.KotlinLogging
-
-val logger = KotlinLogging.logger { }
 
 @Suppress("unused")
 fun reactionRoleCommands(configuration: Configuration, loggingService: LoggingService) = commands("ReactionRole") {
@@ -39,9 +35,10 @@ fun reactionRoleCommands(configuration: Configuration, loggingService: LoggingSe
                     guildConfig.reactionRoles.add(reactionRole)
                 }
                 respond("Reaction role created")
+                loggingService.guildLog(guild, "Reaction role ${reactionRole.id} created")
             } catch (e: Exception) {
                 respond("Error parsing roles. Make sure IDs $roleIds are valid roles and separated by ` ` if adding multiple roles.")
-                logger.error(e) { buildGuildLogMessage(guild, "Failed to parse roles") }
+                loggingService.guildLog(guild, "Failed to parse roles $roleIds")
             }
         }
     }

--- a/src/main/kotlin/me/ddivad/hawk/dataclasses/Configuration.kt
+++ b/src/main/kotlin/me/ddivad/hawk/dataclasses/Configuration.kt
@@ -29,12 +29,8 @@ data class Configuration(
     fun isFullyConfigured(guild: Guild): Boolean {
         val guildConfiguration = guildConfigurations[guild.id] ?: return false
 
-        if (guildConfiguration.loggingConfiguration.logChannel == null ||
-            guildConfiguration.loggingConfiguration.alertChannel == null
-        ) {
-            return false
-        }
-        return true
+        return !(guildConfiguration.loggingConfiguration.logChannel == null ||
+                guildConfiguration.loggingConfiguration.alertChannel == null)
     }
 }
 

--- a/src/main/kotlin/me/ddivad/hawk/listeners/MessageDeleteListener.kt
+++ b/src/main/kotlin/me/ddivad/hawk/listeners/MessageDeleteListener.kt
@@ -2,17 +2,18 @@ package me.ddivad.hawk.listeners
 
 import dev.kord.core.event.message.MessageDeleteEvent
 import me.ddivad.hawk.dataclasses.Configuration
+import me.ddivad.hawk.services.LoggingService
 import me.jakejmattson.discordkt.dsl.edit
 import me.jakejmattson.discordkt.dsl.listeners
 
 @Suppress("unused")
-fun messageDeleteListener(configuration: Configuration) = listeners {
+fun messageDeleteListener(configuration: Configuration, loggingService: LoggingService) = listeners {
     on<MessageDeleteEvent> {
         val guild = guild ?: return@on
         val guildConfiguration = configuration[guild.id] ?: return@on
         val reactionRole =
             guildConfiguration.reactionRoles.find { it.channel == channelId && it.messageId == messageId } ?: return@on
-
+        loggingService.guildLog(guild.asGuild(), "Reaction role ${reactionRole.id} deleted. Removing from config")
         configuration.edit {
             guildConfiguration.reactionRoles.remove(reactionRole)
         }

--- a/src/main/kotlin/me/ddivad/hawk/services/LoggingService.kt
+++ b/src/main/kotlin/me/ddivad/hawk/services/LoggingService.kt
@@ -36,6 +36,11 @@ class LoggingService(private val config: Configuration) {
         "**Info** :: Blocklisted symbols detected and removed from ${member.idDescriptor()} (${member.displayName})"
     }
 
+    fun guildLog(guild: Guild, message: String) = withLog(guild) {
+        logger.info { buildGuildLogMessage(guild, message) }
+        "**Info** :: $message"
+    }
+
     private fun withLog(guild: Guild, f: () -> String) =
         getLogConfig(guild).apply {
             runBlocking {
@@ -57,6 +62,6 @@ class LoggingService(private val config: Configuration) {
 
     private suspend fun alert(guild: Guild, alertChannelId: Snowflake, message: String) =
         guild.getChannelOf<TextChannel>(alertChannelId).createMessage(message)
+    private fun buildGuildLogMessage(guild: Guild, message: String) = "${guild.name} (${guild.id}): $message"
 }
 
-fun buildGuildLogMessage(guild: Guild, message: String) = "${guild.name} (${guild.id}): $message"

--- a/src/main/kotlin/me/ddivad/hawk/services/StartupService.kt
+++ b/src/main/kotlin/me/ddivad/hawk/services/StartupService.kt
@@ -1,48 +1,53 @@
 package me.ddivad.hawk.services
 
 import dev.kord.core.behavior.getChannelOfOrNull
-import dev.kord.core.entity.channel.TextChannel
+import dev.kord.core.entity.Guild
+import dev.kord.core.entity.channel.GuildMessageChannel
 import me.ddivad.hawk.dataclasses.Configuration
+import me.ddivad.hawk.dataclasses.ReactionRole
 import me.ddivad.hawk.embeds.createReactionRoleMenu
 import me.jakejmattson.discordkt.Discord
 import me.jakejmattson.discordkt.annotations.Service
 import me.jakejmattson.discordkt.extensions.createMenu
-import mu.KotlinLogging
-
-val logger = KotlinLogging.logger { }
 
 @Service
 class StartupService(
     private val configuration: Configuration,
     private val discord: Discord,
+    private val loggingService: LoggingService
 ) {
     suspend fun refreshReactionRoleInteractions() {
-        configuration.guildConfigurations.forEach { config ->
-            val guild = config.value.let { discord.kord.getGuild(config.key) } ?: return@forEach
-            val guildConfig = configuration[guild.id] ?: return@forEach
+        configuration.guildConfigurations.forEach { (guildId, guildConfig) ->
+            val guild = discord.kord.getGuild(guildId) ?: return@forEach
             if (guildConfig.reactionRoles.isEmpty()) return@forEach
-            logger.info {
-                buildGuildLogMessage(
-                    guild,
-                    "Refreshing ${guildConfig.reactionRoles.size} reaction roles for ${guild.name}"
-                )
-            }
-
-            guildConfig.reactionRoles.forEach {
-                val channel = guild.getChannelOfOrNull<TextChannel>(it.channel) ?: return
-                val message = channel.getMessageOrNull(it.messageId!!) ?: return
-                logger.info {
-                    buildGuildLogMessage(
-                        guild,
-                        "Refreshing reaction role ${it.id} - ${it.messageId} - ${(it.roles).joinToString()}"
-                    )
-                }
-                message.delete()
-                it.messageId = channel.createMenu {
-                    createReactionRoleMenu(discord, guild, it)
-                }.id
-            }
+            loggingService.guildLog(
+                guild,
+                "Refreshing ${guildConfig.reactionRoles.size} reaction roles for ${guild.name}"
+            )
+            val reactionRolesToDelete = guildConfig.reactionRoles.filterNot { it.refresh(guild) }.toMutableList()
+            reactionRolesToDelete.forEach { guildConfig.reactionRoles.remove(it) }
             configuration.save()
+        }
+    }
+
+    private suspend fun ReactionRole.refresh(guild: Guild): Boolean {
+        loggingService.guildLog(guild, "Attempting to refresh reaction role $id - $messageId - ${roles.joinToString()}")
+        val channel = guild.getChannelOfOrNull<GuildMessageChannel>(channel)
+        val message = messageId?.let { channel?.getMessageOrNull(it) }
+        val reactionRole = this
+        if (channel != null && message != null) {
+            message.delete()
+            val newMessage = channel.createMenu { createReactionRoleMenu(discord, guild, reactionRole) }
+            newMessage.pin()
+            messageId = newMessage.id
+            loggingService.guildLog(guild, "Reaction role $id refreshed. New message ID: ${newMessage.id}")
+            return true
+        } else {
+            loggingService.guildLog(
+                guild,
+                "Channel or message for reaction role $id no longer exist, flagging for deletion"
+            )
+            return false
         }
     }
 }

--- a/src/main/kotlin/me/ddivad/hawk/services/nickname/NicknameService.kt
+++ b/src/main/kotlin/me/ddivad/hawk/services/nickname/NicknameService.kt
@@ -3,6 +3,7 @@ package me.ddivad.hawk.services.nickname
 import dev.kord.core.behavior.edit
 import dev.kord.core.entity.Guild
 import dev.kord.core.entity.Member
+import dev.kord.core.entity.channel.GuildChannel
 import dev.kord.core.entity.channel.TextChannel
 import me.ddivad.hawk.dataclasses.Configuration
 import me.ddivad.hawk.dataclasses.FurryNames
@@ -18,7 +19,7 @@ class NicknameService(
     private val loggingService: LoggingService,
     private val furryNames: FurryNames
 ) {
-    suspend fun setOrRemovePartyNickname(guild: Guild, member: Member, channel: TextChannel) {
+    suspend fun setOrRemovePartyNickname(guild: Guild, member: Member, channel: GuildChannel) {
         val partyConfiguration = configuration[guild.id]?.partyModeConfiguration ?: return
         if (member.isBot) {
             return


### PR DESCRIPTION
# chore: miscellaneous refactoring to cleanup code

- Update logging to use `LoggingService` in more places.
- Add new `guildLog` function to `LoggingService` to clean up various logs.
- Update `StartupService` to add more logs, remove reaction roles if channel or message is no longer present. Also pin the new reaction role message when it gets refreshed.
- Fix casting error from any non `TextChannel` in a guild.